### PR TITLE
Adding Attr Accessible

### DIFF
--- a/app/models/spree/taxon_map.rb
+++ b/app/models/spree/taxon_map.rb
@@ -1,5 +1,7 @@
 module Spree
   class TaxonMap < ActiveRecord::Base
     belongs_to :taxons
+    
+    attr_accessible :product_type, :taxon_id, :priority
   end
 end


### PR DESCRIPTION
Nothing exciting, just adding 

```
attr_accessible :product_type, :taxon_id, :priority
```

to TaxonMap for Rails 3.2.3 and Spree 1.1
