### PR TITLE
Added generate_test_file class method to FeedBuilder

### DIFF
--- a/lib/spree_google_base/feed_builder.rb
+++ b/lib/spree_google_base/feed_builder.rb
@@ -11,7 +11,15 @@ module SpreeGoogleBase
         builder.generate_and_transfer_store
       end
     end
-    
+
+    def self.generate_test_file(file_path)
+      exporter = new
+
+      File.open(file_path, "w") do |file|
+        exporter.generate_xml file
+      end
+    end
+
     def self.builders
       if defined?(Spree::Store)
         Spree::Store.all.map{ |store| self.new(:store => store) }

--- a/lib/tasks/spree_google_base_extension_tasks.rake
+++ b/lib/tasks/spree_google_base_extension_tasks.rake
@@ -4,4 +4,13 @@ namespace :spree_google_base do
   task :generate_and_transfer => [:environment] do |t, args|
     SpreeGoogleBase::FeedBuilder.generate_and_transfer
   end
+
+  task :generate_test_file => [:environment] do |t, args|
+    puts "Dumping product catalog as Google Base XML"
+
+    file_path = Rails.root.join("tmp", "google_base_products.xml")
+    SpreeGoogleBase::FeedBuilder.generate_test_file(file_path)
+
+    puts "Finished dumping product catalog as Google Base XML. See it at [#{file_path}]."
+  end
 end


### PR DESCRIPTION
Hi Denis!  I've had to extend this code a bit to make it meet current client needs.  One thing I found myself doing regularly was going into the console to generate an XML dump for us to look over.  I went ahead and built a class method and rake task to do just that.  It leverages all of your existing functionality, just a slightly different sequence of calls.

Hope you can use this!
Daniel
